### PR TITLE
Remove duplicate entry

### DIFF
--- a/blog/2018-09-11-testing-in-the-modular-world.md
+++ b/blog/2018-09-11-testing-in-the-modular-world.md
@@ -217,8 +217,6 @@ Here are the additional command line options needed to achieve the same modular 
 
 ```text
 --add-opens                                   | "open module com.xyz"
-  com.xyz/com.abc=org.junit.platform.commons  |
---add-opens                                   |
   com.xyz/com.xyz=org.junit.platform.commons  |
 
 --add-reads                                   | "requires org.junit.jupiter.api"


### PR DESCRIPTION
I think the `com.xyz/com.abc=org.junit.platform.commons` entry is probably a duplicate/copy-paste leftover, mostly because there is no `com.abc` package in the rest of the page... or I'm still missing some details 😅 